### PR TITLE
Attempt to add available field in book

### DIFF
--- a/src/DAO/Book.ts
+++ b/src/DAO/Book.ts
@@ -12,20 +12,22 @@ export default class Book extends BaseEntity<typeof Book> {
 	id!: string;
 	title!: string;
 	authors!: string[];
+	available!: number;
 
 	get ISBN(): string { return this.id; }
 	set ISBN(isbn: string) { this.id = isbn; }
 
-	constructor(isbn: string, title: string, authors: string[]) {
+	constructor(isbn: string, title: string, authors: string[], available: number) {
 		super();
 		this.id = isbn;
 		this.title = title;
 		this.authors = authors;
+		this.available = available;
 	}
 
-	static unwrap(wrapped: IBook): Book {
+	static unwrap(wrapped: IBook & { available: number }): Book {
 		const authors = wrapped.authors.split('\n');
-		const book = new Book(wrapped.id, wrapped.title, authors);
+		const book = new Book(wrapped.id, wrapped.title, authors, wrapped.available);
 		book.entry = wrapped.id;
 		return book;
 	}

--- a/src/DAO/Book.ts
+++ b/src/DAO/Book.ts
@@ -12,17 +12,18 @@ export default class Book extends BaseEntity<typeof Book> {
 	id!: string;
 	title!: string;
 	authors!: string[];
-	available!: number;
+	readonly #available!: number;
 
 	get ISBN(): string { return this.id; }
 	set ISBN(isbn: string) { this.id = isbn; }
+	get available(): number { return this.#available; }
 
 	constructor(isbn: string, title: string, authors: string[], available: number) {
 		super();
 		this.id = isbn;
 		this.title = title;
 		this.authors = authors;
-		this.available = available;
+		this.#available = available;
 	}
 
 	static unwrap(wrapped: IBook & { available: number }): Book {

--- a/src/DAO/Comment.ts
+++ b/src/DAO/Comment.ts
@@ -23,6 +23,7 @@ interface BookReference {
 	book_id: string;
 	book_title: string;
 	book_authors: string;
+	book_available: number;
 }
 
 export default class Comment extends BaseEntity<typeof Comment> {
@@ -54,7 +55,8 @@ export default class Comment extends BaseEntity<typeof Comment> {
 		const book = Book.unwrap({
 			id: wrapped.book_id,
 			title: wrapped.book_title,
-			authors: wrapped.book_authors
+			authors: wrapped.book_authors,
+			available: wrapped.book_available
 		});
 		const comment = new Comment(user, book, wrapped.content, wrapped.createdTime);
 		comment.entry = wrapped.id;

--- a/src/DAO/Copy.ts
+++ b/src/DAO/Copy.ts
@@ -11,6 +11,7 @@ interface BookReference {
 	book_id: string;
 	book_title: string;
 	book_authors: string;
+	book_available: number;
 }
 
 export default class Copy extends BaseEntity<typeof Copy> {
@@ -29,7 +30,8 @@ export default class Copy extends BaseEntity<typeof Copy> {
 		const book = Book.unwrap({
 			id: wrapped.book_id,
 			title: wrapped.book_title,
-			authors: wrapped.book_authors
+			authors: wrapped.book_authors,
+			available: wrapped.book_available
 		});
 		const copy = new Copy(book);
 		copy.entry = wrapped.id;

--- a/src/DAO/Transaction.ts
+++ b/src/DAO/Transaction.ts
@@ -25,12 +25,13 @@ interface CopyReference {
 	copy_book_id: string;
 	copy_book_title: string;
 	copy_book_authors: string;
+	copy_book_available: number;
 }
 
 export default class Transaction extends BaseEntity<typeof Transaction> {
 	static readonly entityName = 'transaction';
 
-	static readonly fineRate = 1.0; //? TBC
+	static readonly fineRate = 1e-9; //? TBC
 	static readonly timeLimit = 30 * 86400 * 1000; //? TBC
 
 	id!: string;
@@ -50,7 +51,7 @@ export default class Transaction extends BaseEntity<typeof Transaction> {
 		if (this.isFinePaid)
 			return 0;
 		else
-			return Math.max(0, this.returnDate.getTime() - this.dueDate.getTime()) * Transaction.fineRate; //? TBC
+			return parseFloat((Math.max(0, this.returnDate.getTime() - this.dueDate.getTime()) * Transaction.fineRate).toFixed(2)); //? TBC
 	}
 
 	constructor(user: User, copy: Copy, borrowDate: Date = new Date()) {
@@ -75,7 +76,8 @@ export default class Transaction extends BaseEntity<typeof Transaction> {
 			id: wrapped.copy_id,
 			book_id: wrapped.copy_book_id,
 			book_title: wrapped.copy_book_title,
-			book_authors: wrapped.copy_book_authors
+			book_authors: wrapped.copy_book_authors,
+			book_available: wrapped.copy_book_available
 		});
 		const transaction = new Transaction(user, copy, wrapped.borrowDate);
 		transaction.returnDate = wrapped.returnDate;

--- a/src/query/base.ts
+++ b/src/query/base.ts
@@ -5,7 +5,14 @@ const pool = mysql.createPool({
 	port: Number(process.env.MYSQL_PORT ?? 3306),
 	user: process.env.MYSQL_USER,
 	password: process.env.MYSQL_PASSWORD,
-	database: process.env.MYSQL_DATABASE
+	database: process.env.MYSQL_DATABASE,
+	// Cast tinyint(1) to boolean
+	typeCast: (field, next) => {
+		if (field.type === 'TINY' && field.length === 1) {
+			return (field.string() === '1');
+		}
+		return next();
+	}
 });
 
 export default class BaseQuery<T> {


### PR DESCRIPTION
The new field in `book_view` unfortunately introduces inconsistency between DAOs reference book (copy, comment and transaction) and  their views in database. There might be a better way to handle it.

I also fixed a minor bug that the  `tinyint(1)` is not translated to js `boolean`, which is found during debugging frontend.